### PR TITLE
Allow restricting completion of flags

### DIFF
--- a/command.go
+++ b/command.go
@@ -49,7 +49,7 @@ type Flags map[string]Predictor
 // Predict completion of flags names according to command line arguments
 func (f Flags) Predict(a Args) (prediction []string) {
 	for flag := range f {
-		// If the flag starts with a hyphen, we avoid emiting the prediction
+		// If the flag starts with a hyphen, we avoid emitting the prediction
 		// unless the last typed arg contains a hyphen as well.
 		flagHyphenStart := len(flag) != 0 && flag[0] == '-'
 		lastHyphenStart := len(a.Last) != 0 && a.Last[0] == '-'

--- a/complete_test.go
+++ b/complete_test.go
@@ -25,13 +25,6 @@ func TestCompleter_Complete(t *testing.T) {
 				},
 				Args: PredictFiles("*.md"),
 			},
-			"sub3": {
-				Flags: Flags{
-					"-flag4": PredictAnything,
-					"-flag5": PredictNothing,
-				},
-				FlagsRequirePrefix: "-",
-			},
 		},
 		Flags: Flags{
 			"-o": PredictFiles("*.txt"),
@@ -48,7 +41,7 @@ func TestCompleter_Complete(t *testing.T) {
 	}{
 		{
 			args: "",
-			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2"},
 		},
 		{
 			args: "-",
@@ -56,7 +49,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "-h ",
-			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2"},
 		},
 		{
 			args: "-global1 ", // global1 is known follow flag
@@ -64,7 +57,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "sub",
-			want: []string{"sub1", "sub2", "sub3"},
+			want: []string{"sub1", "sub2"},
 		},
 		{
 			args: "sub1",
@@ -75,16 +68,16 @@ func TestCompleter_Complete(t *testing.T) {
 			want: []string{"sub2"},
 		},
 		{
-			args: "sub3",
-			want: []string{"sub3"},
+			args: "sub1 ",
+			want: []string{},
 		},
 		{
-			args: "sub1 ",
+			args: "sub1 -",
 			want: []string{"-flag1", "-flag2", "-h", "-global1"},
 		},
 		{
 			args: "sub2 ",
-			want: []string{"./", "dir/", "outer/", "readme.md", "-flag2", "-flag3", "-h", "-global1"},
+			want: []string{"./", "dir/", "outer/", "readme.md"},
 		},
 		{
 			args: "sub2 ./",
@@ -100,7 +93,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "sub2 -flag2 ",
-			want: []string{"./", "dir/", "outer/", "readme.md", "-flag2", "-flag3", "-h", "-global1"},
+			want: []string{"./", "dir/", "outer/", "readme.md"},
 		},
 		{
 			args: "sub1 -fl",
@@ -115,16 +108,8 @@ func TestCompleter_Complete(t *testing.T) {
 			want: []string{}, // flag1 is unknown follow flag
 		},
 		{
-			args: "sub1 -flag2 ",
+			args: "sub1 -flag2 -",
 			want: []string{"-flag1", "-flag2", "-h", "-global1"},
-		},
-		{
-			args: "sub3 ",
-			want: []string{"-h", "-global1"},
-		},
-		{
-			args: "sub3 -",
-			want: []string{"-flag4", "-flag5", "-h", "-global1"},
 		},
 		{
 			args: "-no-such-flag",
@@ -132,7 +117,11 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "-no-such-flag ",
-			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2"},
+		},
+		{
+			args: "-no-such-flag -",
+			want: []string{"-h", "-global1", "-o"},
 		},
 		{
 			args: "no-such-command",
@@ -140,7 +129,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "no-such-command ",
-			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2"},
 		},
 		{
 			args: "-o ",
@@ -168,7 +157,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "-o ./readme.md ",
-			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2"},
 		},
 		{
 			args: "-o sub2 -flag3 ",

--- a/complete_test.go
+++ b/complete_test.go
@@ -228,7 +228,7 @@ func TestCompleter_Complete_SharedPrefix(t *testing.T) {
 	}{
 		{
 			args: "",
-			want: []string{"status", "job", "-h", "-global1", "-o"},
+			want: []string{"status", "job"},
 		},
 		{
 			args: "-",
@@ -240,10 +240,18 @@ func TestCompleter_Complete_SharedPrefix(t *testing.T) {
 		},
 		{
 			args: "job ",
-			want: []string{"-h", "-global1", "status"},
+			want: []string{"status"},
+		},
+		{
+			args: "job -",
+			want: []string{"-h", "-global1"},
 		},
 		{
 			args: "job status ",
+			want: []string{},
+		},
+		{
+			args: "job status -",
 			want: []string{"-f4", "-h", "-global1"},
 		},
 	}

--- a/complete_test.go
+++ b/complete_test.go
@@ -25,6 +25,13 @@ func TestCompleter_Complete(t *testing.T) {
 				},
 				Args: PredictFiles("*.md"),
 			},
+			"sub3": {
+				Flags: Flags{
+					"-flag4": PredictAnything,
+					"-flag5": PredictNothing,
+				},
+				FlagsRequirePrefix: "-",
+			},
 		},
 		Flags: Flags{
 			"-o": PredictFiles("*.txt"),
@@ -41,7 +48,7 @@ func TestCompleter_Complete(t *testing.T) {
 	}{
 		{
 			args: "",
-			want: []string{"sub1", "sub2", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
 		},
 		{
 			args: "-",
@@ -49,7 +56,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "-h ",
-			want: []string{"sub1", "sub2", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
 		},
 		{
 			args: "-global1 ", // global1 is known follow flag
@@ -57,7 +64,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "sub",
-			want: []string{"sub1", "sub2"},
+			want: []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			args: "sub1",
@@ -66,6 +73,10 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			args: "sub2",
 			want: []string{"sub2"},
+		},
+		{
+			args: "sub3",
+			want: []string{"sub3"},
 		},
 		{
 			args: "sub1 ",
@@ -108,12 +119,20 @@ func TestCompleter_Complete(t *testing.T) {
 			want: []string{"-flag1", "-flag2", "-h", "-global1"},
 		},
 		{
+			args: "sub3 ",
+			want: []string{"-h", "-global1"},
+		},
+		{
+			args: "sub3 -",
+			want: []string{"-flag4", "-flag5", "-h", "-global1"},
+		},
+		{
 			args: "-no-such-flag",
 			want: []string{},
 		},
 		{
 			args: "-no-such-flag ",
-			want: []string{"sub1", "sub2", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
 		},
 		{
 			args: "no-such-command",
@@ -121,7 +140,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "no-such-command ",
-			want: []string{"sub1", "sub2", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
 		},
 		{
 			args: "-o ",
@@ -149,7 +168,7 @@ func TestCompleter_Complete(t *testing.T) {
 		},
 		{
 			args: "-o ./readme.md ",
-			want: []string{"sub1", "sub2", "-h", "-global1", "-o"},
+			want: []string{"sub1", "sub2", "sub3", "-h", "-global1", "-o"},
 		},
 		{
 			args: "-o sub2 -flag3 ",


### PR DESCRIPTION
This PR allows a command to specify that flags should only be completed
when a prefix is present. The motivation behind this is to have the
initial complation to prefer displaying argument completions and only
display flag completions when the user enters "hyphen <tab>".