### PR TITLE
install/bash: add more configuration files

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -59,7 +59,7 @@ func Uninstall(cmd string) error {
 }
 
 func installers() (i []installer) {
-	for _, rc := range [...]string{".bashrc", ".bash_profile"} {
+	for _, rc := range [...]string{".bashrc", ".bash_profile", ".bash_login", ".profile"} {
 		if f := rcFile(rc); f != "" {
 			i = append(i, bash{f})
 			break


### PR DESCRIPTION
…les the -install-autocomplete fails with :

Error executing CLI: Did not find any shells to install

excerpt from bash man page

    When bash is invoked as an interactive login shell, or as a non-interactive shell with the --login option, it first reads and executes commands from the file /etc/profile, if that file exists. After reading that file, it looks for ~/.bash_profile, ~/.bash_login, and ~/.profile, in that order, and reads and executes commands from the first one that exists and is readable. The --noprofile option may be used when the shell is started to inhibit this behavior.

    When an interactive shell that is not a login shell is started, bash reads and executes commands from /etc/bash.bashrc and ~/.bashrc, if these files exist. This may be inhibited by using the --norc option. The --rcfile file option will force bash to read and execute commands from file instead of /etc/bash.bashrc and ~/.bashrc.