### PR TITLE
Minor option fix for go tool objdump and asm

### DIFF
--- a/gocomplete/complete.go
+++ b/gocomplete/complete.go
@@ -274,6 +274,7 @@ func main() {
 			"objdump": {
 				Flags: complete.Flags{
 					"-s": complete.PredictAnything,
+					"-S": complete.PredictNothing,
 				},
 				Args: anyFile,
 			},

--- a/gocomplete/complete.go
+++ b/gocomplete/complete.go
@@ -148,6 +148,7 @@ func main() {
 					"-D":        complete.PredictAnything,
 					"-I":        complete.PredictDirs("*"),
 					"-S":        complete.PredictNothing,
+					"-V":        complete.PredictNothing,
 					"-debug":    complete.PredictNothing,
 					"-dynlink":  complete.PredictNothing,
 					"-e":        complete.PredictNothing,


### PR DESCRIPTION
Added two missing options for go tool objdump and asm.
These options appear in Go 1.10rc2.