### PR TITLE
Go 1.11 completion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 coverage.txt
+gocomplete/gocomplete
+example/self/self

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ go:
 
 before_install:
   - go get -u -t ./...
-  - go get -u gopkg.in/alecthomas/gometalinter.v2
-  - gometalinter.v2 --install
+  - go version | grep go1.11 &>/dev/null && go get -u gopkg.in/alecthomas/gometalinter.v2
+  - go version | grep go1.11 &>/dev/null && gometalinter.v2 --install
 
 script:
-  - gometalinter.v2 --config metalinter.json ./...
+  - go version | grep go1.11 &>/dev/null && gometalinter.v2 --config metalinter.json ./...
   - GO111MODULE=on ./test.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: go
 sudo: false
 go:
+  - 1.11
+  - 1.10.x
   - 1.9
   - 1.8
 
 before_install:
-  - go get -u -t ./...
-  - go get -u gopkg.in/alecthomas/gometalinter.v1
+  - GO111MODULE=on go get -u -t ./...
+  - GO111MODULE=on go get -u gopkg.in/alecthomas/gometalinter.v1
   - gometalinter.v1 --install
 
 script:
   - gometalinter.v1 --config metalinter.json ./...
-  - ./test.sh
+  - GO111MODULE=on ./test.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ go:
 
 before_install:
   - go get -u -t ./...
-  - go version | grep go1.11 &>/dev/null && go get -u gopkg.in/alecthomas/gometalinter.v2
-  - go version | grep go1.11 &>/dev/null && gometalinter.v2 --install
+  - if go version | grep go1.11 &>/dev/null ; then go get -u gopkg.in/alecthomas/gometalinter.v2; fi
+  - if go version | grep go1.11 &>/dev/null ; then gometalinter.v2 --install; fi
 
 script:
-  - go version | grep go1.11 &>/dev/null && gometalinter.v2 --config metalinter.json ./...
+  - if go version | grep go1.11 &>/dev/null ; then gometalinter.v2 --config metalinter.json ./... ; fi
   - GO111MODULE=on ./test.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ go:
   - 1.8
 
 before_install:
-  - GO111MODULE=on go get -u -t ./...
-  - GO111MODULE=on go get -u gopkg.in/alecthomas/gometalinter.v1
-  - gometalinter.v1 --install
+  - go get -u -t ./...
+  - go get -u gopkg.in/alecthomas/gometalinter.v2
+  - gometalinter.v2 --install
 
 script:
-  - gometalinter.v1 --config metalinter.json ./...
+  - gometalinter.v2 --config metalinter.json ./...
   - GO111MODULE=on ./test.sh
 
 after_success:

--- a/cmd/install/fish.go
+++ b/cmd/install/fish.go
@@ -46,5 +46,5 @@ end
 complete -c {{.Cmd}} -a "(__complete_{{.Cmd}})"
 `)).Execute(&buf, params)
 
-	return string(buf.Bytes())
+	return buf.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/posener/complete
+
+require github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=

--- a/gocomplete/complete.go
+++ b/gocomplete/complete.go
@@ -449,7 +449,7 @@ func main() {
 					"-unusedfuncs":         complete.PredictAnything,
 					"-unusedresult":        complete.PredictNothing,
 					"-unusedstringmethods": complete.PredictAnything,
-					"-v": complete.PredictNothing,
+					"-v":                   complete.PredictNothing,
 				},
 				Args: anyGo,
 			},
@@ -458,10 +458,13 @@ func main() {
 
 	clean := complete.Command{
 		Flags: complete.Flags{
-			"-i": complete.PredictNothing,
-			"-r": complete.PredictNothing,
-			"-n": complete.PredictNothing,
-			"-x": complete.PredictNothing,
+			"-i":         complete.PredictNothing,
+			"-r":         complete.PredictNothing,
+			"-n":         complete.PredictNothing,
+			"-x":         complete.PredictNothing,
+			"-cache":     complete.PredictNothing,
+			"-testcache": complete.PredictNothing,
+			"-modcache":  complete.PredictNothing,
 		},
 		Args: complete.PredictOr(anyPackage, ellipsis),
 	}

--- a/gocomplete/complete.go
+++ b/gocomplete/complete.go
@@ -480,6 +480,121 @@ func main() {
 		Args: anyGo,
 	}
 
+	modDownload := complete.Command{
+		Flags: complete.Flags{
+			"-json": complete.PredictNothing,
+		},
+		Args: anyPackage,
+	}
+
+	modEdit := complete.Command{
+		Flags: complete.Flags{
+			"-fmt":    complete.PredictNothing,
+			"-module": complete.PredictNothing,
+			"-print":  complete.PredictNothing,
+
+			"-exclude":     anyPackage,
+			"-dropexclude": anyPackage,
+			"-replace":     anyPackage,
+			"-dropreplace": anyPackage,
+			"-require":     anyPackage,
+			"-droprequire": anyPackage,
+		},
+		Args: complete.PredictFiles("go.mod"),
+	}
+
+	modGraph := complete.Command{}
+
+	modInit := complete.Command{
+		Args: complete.PredictAnything,
+	}
+
+	modTidy := complete.Command{
+		Flags: complete.Flags{
+			"-v": complete.PredictNothing,
+		},
+	}
+
+	modVendor := complete.Command{
+		Flags: complete.Flags{
+			"-v": complete.PredictNothing,
+		},
+	}
+
+	modVerify := complete.Command{}
+
+	modWhy := complete.Command{
+		Flags: complete.Flags{
+			"-m":      complete.PredictNothing,
+			"-vendor": complete.PredictNothing,
+		},
+		Args: anyPackage,
+	}
+
+	modHelp := complete.Command{
+		Sub: complete.Commands{
+			"download": complete.Command{},
+			"edit":     complete.Command{},
+			"graph":    complete.Command{},
+			"init":     complete.Command{},
+			"tidy":     complete.Command{},
+			"vendor":   complete.Command{},
+			"verify":   complete.Command{},
+			"why":      complete.Command{},
+		},
+	}
+
+	mod := complete.Command{
+		Sub: complete.Commands{
+			"download": modDownload,
+			"edit":     modEdit,
+			"graph":    modGraph,
+			"init":     modInit,
+			"tidy":     modTidy,
+			"vendor":   modVendor,
+			"verify":   modVerify,
+			"why":      modWhy,
+			"help":     modHelp,
+		},
+	}
+
+	help := complete.Command{
+		Sub: complete.Commands{
+			"bug":         complete.Command{},
+			"build":       complete.Command{},
+			"clean":       complete.Command{},
+			"doc":         complete.Command{},
+			"env":         complete.Command{},
+			"fix":         complete.Command{},
+			"fmt":         complete.Command{},
+			"generate":    complete.Command{},
+			"get":         complete.Command{},
+			"install":     complete.Command{},
+			"list":        complete.Command{},
+			"mod":         modHelp,
+			"run":         complete.Command{},
+			"test":        complete.Command{},
+			"tool":        complete.Command{},
+			"version":     complete.Command{},
+			"vet":         complete.Command{},
+			"buildmode":   complete.Command{},
+			"c":           complete.Command{},
+			"cache":       complete.Command{},
+			"environment": complete.Command{},
+			"filetype":    complete.Command{},
+			"go.mod":      complete.Command{},
+			"gopath":      complete.Command{},
+			"gopath-get":  complete.Command{},
+			"goproxy":     complete.Command{},
+			"importpath":  complete.Command{},
+			"modules":     complete.Command{},
+			"module-get":  complete.Command{},
+			"packages":    complete.Command{},
+			"testflag":    complete.Command{},
+			"testfunc":    complete.Command{},
+		},
+	}
+
 	// commands that also accepts the build flags
 	for name, options := range build.Flags {
 		test.Flags[name] = options
@@ -507,6 +622,8 @@ func main() {
 			"bug":      bug,
 			"fix":      fix,
 			"version":  version,
+			"mod":      mod,
+			"help":     help,
 		},
 		GlobalFlags: complete.Flags{
 			"-h": complete.PredictNothing,

--- a/gocomplete/go.mod
+++ b/gocomplete/go.mod
@@ -1,0 +1,6 @@
+module gocomplete
+
+require (
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/posener/complete v1.1.2
+)

--- a/gocomplete/go.sum
+++ b/gocomplete/go.sum
@@ -1,0 +1,6 @@
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/posener/complete v1.1.2 h1:fS9GkqLN9DIpHg9j3fAPHdj5P3LhzxuoSybQd1v26IE=
+github.com/posener/complete v1.1.2/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/log.go
+++ b/log.go
@@ -1,7 +1,6 @@
 package complete
 
 import (
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -15,7 +14,7 @@ import (
 var Log = getLogger()
 
 func getLogger() func(format string, args ...interface{}) {
-	var logfile io.Writer = ioutil.Discard
+	var logfile = ioutil.Discard
 	if os.Getenv(envDebug) != "" {
 		logfile = os.Stderr
 	}


### PR DESCRIPTION
This PR adds go module support for the complete package and also expands the gocomplete completion program for the go command to include completion for `go help` and `go mod`. 

This PR also adds some missing flags for `go clean`.