### PR TITLE
Fix fish shell completion

### DIFF
--- a/cmd/install/fish.go
+++ b/cmd/install/fish.go
@@ -41,12 +41,12 @@ func (f fish) cmd(cmd, bin string) (string, error) {
 	params := struct{ Cmd, Bin string }{cmd, bin}
 	tmpl := template.Must(template.New("cmd").Parse(`
 function __complete_{{.Cmd}}
-    set -lx COMP_LINE (string join ' ' (commandline -o))
-    test (commandline -ct) = ""
+    set -lx COMP_LINE (commandline -cp)
+    test -z (commandline -ct)
     and set COMP_LINE "$COMP_LINE "
     {{.Bin}}
 end
-complete -c {{.Cmd}} -a "(__complete_{{.Cmd}})"
+complete -f -c {{.Cmd}} -a "(__complete_{{.Cmd}})"
 `))
 	err := tmpl.Execute(&buf, params)
 	if err != nil {


### PR DESCRIPTION
`commandline -cp` returns the content of the commandline up the the current (c)ursor position for the (p)rocess – there's no need to use `string join` etc.

It also fixes an issue when trying to complete `--`:

```
› foo --barstring join: Unknown option “--foo”
~/.config/fish/completions/foo.fish (line 3):
string join ' ' (commandline -o)
^
in command substitution
  called on line 5 of file ~/.config/fish/completions/foo.fish

in function “__complete_foo”
  called on standard input

in command substitution
  called on standard input
```

---

I've also added `-f` to the `complete` invocation which disables file completion.

