### PR TITLE
Install in ~/.bash_profile first in case of macOS

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -59,7 +60,16 @@ func Uninstall(cmd string) error {
 }
 
 func installers() (i []installer) {
-	for _, rc := range [...]string{".bashrc", ".bash_profile", ".bash_login", ".profile"} {
+	// The list of bash config files candidates where it is
+	// possible to install the completion command.
+	var bashConfFiles []string
+	switch runtime.GOOS {
+	case "darwin":
+		bashConfFiles = []string{".bash_profile"}
+	default:
+		bashConfFiles = []string{".bashrc", ".bash_profile", ".bash_login", ".profile"}
+	}
+	for _, rc := range bashConfFiles {
 		if f := rcFile(rc); f != "" {
 			i = append(i, bash{f})
 			break


### PR DESCRIPTION
Some macOS users have ~/.bashrc which is not loaded from
~/.bash_profile, which means, completion will never be
loaded when users open a terminal.

This commit will make macOS a special case and will always
tend to install in ~/.bash_profile