### PR TITLE
Allow user to set the "hasPrefix" function in Complete()

### DIFF
--- a/complete_test.go
+++ b/complete_test.go
@@ -283,13 +283,6 @@ func TestCompleter_Complete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s@%d", tt.line, tt.point), func(t *testing.T) {
-			//if len(tt.completeArgs) == 0 {
-			//	tt.completeArgs = []CompleteArg{
-			//		WithMatcher(func(str, prefix string) bool {
-			//			return true
-			//		}),
-			//	}
-			//}
 			got := runComplete(cmp, tt.line, tt.point, tt.completeArgs)
 
 			sort.Strings(tt.want)


### PR DESCRIPTION
This PR comes from my desire to have case- and diacritic-insensitive completions. I have a command that takes usernames as arguments. When I type "wi<tab><tab>" for the username argument I want to see "WillAbides" listed along with the usernames that start with lowercase "wi". The code currently in master doesn't allow for this because it always applies `strings.HasPrefix(option, a.Last)`.

The simplest place I found to add this without affecting the other usage was as a variadic argument to `Complete()`.  The down side to making it an argument to `Complete()` is that means all arguments will use the same hasPrefix func.

In case it helps to understand the use case, this is a simplified version of how I implemented case-insensitive completions:

```go
package main

import (
	"github.com/posener/complete"
	"golang.org/x/text/language"
	"golang.org/x/text/search"
)

var insensitiveSearch = search.New(language.Und, search.IgnoreCase, search.IgnoreDiacritics, search.IgnoreWidth)

func hasPrefix(in, prefix string) bool {
	if len(prefix) == 0 {
		return true
	}
	if len(prefix) > len(in) {
		return false
	}
	return insensitiveSearch.Equal([]byte(in[0:len(prefix)]), []byte(prefix))
}

func main() {
	cmp := complete.New("my_command", complete.Command{
	//	config removed
	})
	if cmp.Complete(complete.WithMatcher(hasPrefix)) {
		return
	}
	
	// do other stuff
}
```