### PR TITLE
Set custom prefix filter on predictor

### DIFF
--- a/command.go
+++ b/command.go
@@ -84,10 +84,10 @@ func (c *Command) predict(a Args) (options []string, only bool) {
 	// if last completed word is a global flag that we need to complete
 	if predictor, ok := c.GlobalFlags[a.LastCompleted]; ok && predictor != nil {
 		Log("Predicting according to global flag %s", a.LastCompleted)
-		return predictor.Predict(a), true
+		return predictAndFilterPrefix(predictor, a), true
 	}
 
-	options = append(options, c.GlobalFlags.Predict(a)...)
+	options = append(options, predictAndFilterPrefix(c.GlobalFlags, a)...)
 
 	// if a sub command was entered, we won't add the parent command
 	// completions and we return here.
@@ -98,13 +98,13 @@ func (c *Command) predict(a Args) (options []string, only bool) {
 	// if last completed word is a command flag that we need to complete
 	if predictor, ok := c.Flags[a.LastCompleted]; ok && predictor != nil {
 		Log("Predicting according to flag %s", a.LastCompleted)
-		return predictor.Predict(a), true
+		return predictAndFilterPrefix(predictor, a), true
 	}
 
-	options = append(options, c.Sub.Predict(a)...)
-	options = append(options, c.Flags.Predict(a)...)
+	options = append(options, predictAndFilterPrefix(c.Sub, a)...)
+	options = append(options, predictAndFilterPrefix(c.Flags, a)...)
 	if c.Args != nil {
-		options = append(options, c.Args.Predict(a)...)
+		options = append(options, predictAndFilterPrefix(c.Args, a)...)
 	}
 
 	return

--- a/complete.go
+++ b/complete.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/posener/complete/cmd"
 )
@@ -69,15 +68,7 @@ func (c *Complete) Complete() bool {
 	options := c.Command.Predict(a)
 	Log("Options: %s", options)
 
-	// filter only options that match the last argument
-	matches := []string{}
-	for _, option := range options {
-		if strings.HasPrefix(option, a.Last) {
-			matches = append(matches, option)
-		}
-	}
-	Log("Matches: %s", matches)
-	c.output(matches)
+	c.output(options)
 	return true
 }
 

--- a/gocomplete/go.sum
+++ b/gocomplete/go.sum
@@ -2,3 +2,5 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/predict.go
+++ b/predict.go
@@ -14,7 +14,7 @@ func PredictOr(predictors ...Predictor) Predictor {
 			if p == nil {
 				continue
 			}
-			prediction = append(prediction, p.Predict(a)...)
+			prediction = append(prediction, predictAndFilterPrefix(p, a)...)
 		}
 		return
 	})
@@ -39,3 +39,19 @@ var PredictNothing Predictor
 // PredictAnything expects something, but nothing particular, such as a number
 // or arbitrary name.
 var PredictAnything = PredictFunc(func(Args) []string { return nil })
+
+func predictAndFilterPrefix(p Predictor, a Args) []string {
+	options := p.Predict(a)
+	prefixerFunc := DefaultPrefixFilter
+	prefixFilter, ok := p.(PrefixFilter)
+	if ok {
+		prefixerFunc = prefixFilter.FilterPrefix
+	}
+	matches := make([]string, 0, len(options))
+	for _, option := range options {
+		if prefixerFunc(option, a.Last) {
+			matches = append(matches, option)
+		}
+	}
+	return matches
+}

--- a/predict_test.go
+++ b/predict_test.go
@@ -3,10 +3,45 @@ package complete
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
 )
+
+func Test_predictAndFilterPrefix(t *testing.T) {
+	t.Parallel()
+	initTests()
+
+	t.Run("default prefix filter", func(t *testing.T) {
+		predictor := PredictSet("a", "ab", "b", "c")
+		args := Args{
+			Last: "a",
+		}
+		want := []string{"a", "ab"}
+		got := predictAndFilterPrefix(predictor, args)
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("unexpected result\nwant: %v\ngot:  %v", want, got)
+		}
+	})
+
+	t.Run("permissive filter", func(t *testing.T) {
+		predictor := PredictSet("a", "ab", "b", "c")
+		predictor = &PrefixFilteringPredictor{
+			Predictor:        predictor,
+			PrefixFilterFunc: PermissivePrefixFilter,
+		}
+
+		args := Args{
+			Last: "a",
+		}
+		want := []string{"a", "ab", "b", "c"}
+		got := predictAndFilterPrefix(predictor, args)
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("unexpected result\nwant: %v\ngot:  %v", want, got)
+		}
+	})
+}
 
 func TestPredicate(t *testing.T) {
 	t.Parallel()

--- a/prefixfilter.go
+++ b/prefixfilter.go
@@ -1,0 +1,48 @@
+package complete
+
+import (
+	"strings"
+)
+
+//PrefixFilter filters a predictor's options based on the prefix
+type PrefixFilter interface {
+	FilterPrefix(str, prefix string) bool
+}
+
+//PrefixFilteringPredictor is a Predictor that also implements PrefixFilter
+type PrefixFilteringPredictor struct {
+	Predictor        Predictor
+	PrefixFilterFunc func(s, prefix string) bool
+}
+
+func (p *PrefixFilteringPredictor) Predict(a Args) []string {
+	if p.Predictor == nil {
+		return []string{}
+	}
+	return p.Predictor.Predict(a)
+}
+
+func (p *PrefixFilteringPredictor) FilterPrefix(str, prefix string) bool {
+	if p.PrefixFilterFunc == nil {
+		return DefaultPrefixFilter(str, prefix)
+	}
+	return p.PrefixFilterFunc(str, prefix)
+}
+
+//DefaultPrefixFilter is the PrefixFilter used when none is set
+func DefaultPrefixFilter(s, prefix string) bool {
+	return strings.HasPrefix(s, prefix)
+}
+
+//PermissivePrefixFilter always returns true
+func PermissivePrefixFilter(_, _ string) bool {
+	return true
+}
+
+//CaseInsensitivePrefixFilter ignores case differences between the prefix and tested string
+func CaseInsensitivePrefixFilter(s, prefix string) bool {
+	if len(prefix) > len(s) {
+		return false
+	}
+	return strings.EqualFold(prefix, s[:len(prefix)])
+}

--- a/prefixfilter_test.go
+++ b/prefixfilter_test.go
@@ -1,0 +1,151 @@
+package complete
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestPrefixFilteringPredictor_Predict(t *testing.T) {
+	t.Parallel()
+	initTests()
+
+	t.Run("defaults to empty list", func(t *testing.T) {
+		pfp := &PrefixFilteringPredictor{}
+		got := pfp.Predict(Args{})
+		if len(got) != 0 {
+			t.Fail()
+		}
+	})
+
+	t.Run("passes request to Predictor", func(t *testing.T) {
+		args := Args{
+			All: []string{"a"},
+		}
+		want := []string{"b"}
+		predictFunc := PredictFunc(func(a Args) []string {
+			if !reflect.DeepEqual(a, args) {
+				t.Errorf("unexpected args: %v", a)
+			}
+			return want
+		})
+		pfp := &PrefixFilteringPredictor{
+			Predictor: predictFunc,
+		}
+		got := pfp.Predict(args)
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("unexpected result: %v", got)
+		}
+	})
+}
+
+func TestPrefixFilteringPredictor_FilterPrefix(t *testing.T) {
+	t.Parallel()
+	initTests()
+
+	t.Run("default PrefixFilterFunc", func(t *testing.T) {
+		for _, td := range []struct {
+			s      string
+			prefix string
+			want   bool
+		}{
+			{
+				s:      "ohm",
+				prefix: "ohm",
+				want:   true,
+			},
+			{
+				s:      "ohm",
+				prefix: "",
+				want:   true,
+			},
+			{
+				s:      "ohm",
+				prefix: "O",
+				want:   false,
+			},
+			{
+				s:      "ohm",
+				prefix: "q",
+				want:   false,
+			},
+			{
+				s:      "öhm",
+				prefix: "o",
+				want:   false,
+			},
+			{
+				s:      "ohm",
+				prefix: "ohmy",
+				want:   false,
+			},
+		} {
+			t.Run(fmt.Sprintf("%s %s", td.s, td.prefix), func(t *testing.T) {
+				pfp := &PrefixFilteringPredictor{}
+				got := pfp.FilterPrefix(td.s, td.prefix)
+				if td.want != got {
+					t.Errorf("failed %s\ngot: %v\nwant: %v", t.Name(), got, td.want)
+				}
+			})
+		}
+	})
+
+	t.Run("CaseInsensitivePrefixFilter", func(t *testing.T) {
+		for _, td := range []struct {
+			s      string
+			prefix string
+			want   bool
+		}{
+			{
+				s:      "ohm",
+				prefix: "ohm",
+				want:   true,
+			},
+			{
+				s:      "ohm",
+				prefix: "",
+				want:   true,
+			},
+			{
+				s:      "ohm",
+				prefix: "O",
+				want:   true,
+			},
+			{
+				s:      "ohm",
+				prefix: "q",
+				want:   false,
+			},
+			{
+				s:      "öhm",
+				prefix: "o",
+				want:   false,
+			},
+			{
+				s:      "ohm",
+				prefix: "ohmy",
+				want:   false,
+			},
+		} {
+			t.Run(fmt.Sprintf("%s %s", td.s, td.prefix), func(t *testing.T) {
+				pfp := &PrefixFilteringPredictor{
+					PrefixFilterFunc: CaseInsensitivePrefixFilter,
+				}
+				got := pfp.FilterPrefix(td.s, td.prefix)
+				if td.want != got {
+					t.Errorf("failed %s\ngot: %v\nwant: %v", t.Name(), got, td.want)
+				}
+			})
+		}
+	})
+
+	t.Run("PermissivePrefixFilter", func(t *testing.T) {
+		pfp := &PrefixFilteringPredictor{
+			PrefixFilterFunc: PermissivePrefixFilter,
+		}
+		got := pfp.FilterPrefix("", "")
+		if !got {
+			t.Errorf("should have returned true, but didn't")
+		}
+	})
+}


### PR DESCRIPTION
This replaces #99.  I didn't like that you had to change the filter for all arguments or nothing there. This allows the custom prefix filter to be set in the predictor.

It adds the `PrefixFilter` interface.  When a predictor implements PrefixFilter, it will use the supplied filter instead of the default `strings.HasPrefix`.  A new type `PrefixFilteringPredictor` is also introduced.  It wraps both a Predictor and a PrefixFilter.