### PR TITLE
Fix off-by-one error for argument from method

### DIFF
--- a/args.go
+++ b/args.go
@@ -85,16 +85,17 @@ func splitLastEqual(line []string) []string {
 	return append(line[:len(line)-1], parts...)
 }
 
+// from returns a copy of Args of all arguments after the i'th argument.
 func (a Args) from(i int) Args {
-	if i > len(a.All) {
-		i = len(a.All)
+	if i >= len(a.All) {
+		i = len(a.All) - 1
 	}
-	a.All = a.All[i:]
+	a.All = a.All[i+1:]
 
-	if i > len(a.Completed) {
-		i = len(a.Completed)
+	if i >= len(a.Completed) {
+		i = len(a.Completed) - 1
 	}
-	a.Completed = a.Completed[i:]
+	a.Completed = a.Completed[i+1:]
 	return a
 }
 

--- a/args_test.go
+++ b/args_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestArgs(t *testing.T) {
@@ -131,15 +133,11 @@ func TestArgs_From(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s/%d", tt.line, tt.from), func(t *testing.T) {
 
-			a := newArgs(tt.line)
+			a := newArgs("cmd " + tt.line)
 			n := a.from(tt.from)
 
-			if got, want := strings.Join(n.All, " "), tt.newLine; got != want {
-				t.Errorf("%s failed: all = %q, want %q", t.Name(), got, want)
-			}
-			if got, want := strings.Join(n.Completed, " "), tt.newCompleted; got != want {
-				t.Errorf("%s failed: completed = %q, want %q", t.Name(), got, want)
-			}
+			assert.Equal(t, tt.newLine, strings.Join(n.All, " "))
+			assert.Equal(t, tt.newCompleted, strings.Join(n.Completed, " "))
 		})
 	}
 }

--- a/complete_test.go
+++ b/complete_test.go
@@ -20,6 +20,9 @@ func TestCompleter_Complete(t *testing.T) {
 					"-flag1": PredictAnything,
 					"-flag2": PredictNothing,
 				},
+				Sub: Commands{
+					"sub11": {},
+				},
 			},
 			"sub2": {
 				Flags: Flags{
@@ -27,6 +30,11 @@ func TestCompleter_Complete(t *testing.T) {
 					"-flag3": PredictSet("opt1", "opt2", "opt12"),
 				},
 				Args: PredictFiles("*.md"),
+			},
+			"sub3": {
+				Sub: Commands{
+					"sub3": {},
+				},
 			},
 		},
 		Flags: Flags{
@@ -47,7 +55,7 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			line:  "cmd ",
 			point: -1,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			line:  "cmd -",
@@ -57,7 +65,7 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			line:  "cmd -h ",
 			point: -1,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			line:  "cmd -global1 ", // global1 is known follow flag
@@ -67,7 +75,7 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			line:  "cmd sub",
 			point: -1,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			line:  "cmd sub1",
@@ -82,7 +90,12 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			line:  "cmd sub1 ",
 			point: -1,
-			want:  []string{},
+			want:  []string{"sub11"},
+		},
+		{
+			line:  "cmd sub3 ",
+			point: -1,
+			want:  []string{"sub3"},
 		},
 		{
 			line:  "cmd sub1 -",
@@ -142,7 +155,7 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			line:  "cmd -no-such-flag ",
 			point: -1,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			line:  "cmd -no-such-flag -",
@@ -157,7 +170,7 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			line:  "cmd no-such-command ",
 			point: -1,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			line:  "cmd -o ",
@@ -212,12 +225,12 @@ func TestCompleter_Complete(t *testing.T) {
 		{
 			line:  "cmd -o ./readme.md ",
 			point: -1,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			line:  "cmd -o=./readme.md ",
 			point: -1,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 		{
 			line:  "cmd -o sub2 -flag3 ",
@@ -256,7 +269,7 @@ func TestCompleter_Complete(t *testing.T) {
 			line: "cmd -o ",
 			//         ^
 			point: 4,
-			want:  []string{"sub1", "sub2"},
+			want:  []string{"sub1", "sub2", "sub3"},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/posener/complete
 
 require github.com/hashicorp/go-multierror v1.0.0
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/posener/complete
 
-require github.com/hashicorp/go-multierror v1.0.0
+require (
+	github.com/hashicorp/go-multierror v1.0.0
+	github.com/stretchr/testify v1.4.0
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Fix off-by-one error of the `Args.from` method. It used to return all elements including the i'th element, but the expected behavior was to return all elements except the i'th element.

Fixes #97