### PR TITLE
Add check for autoloading compinit in zsh.go

### DIFF
--- a/install/zsh.go
+++ b/install/zsh.go
@@ -6,6 +6,7 @@ import "fmt"
 // basically adds/remove from .zshrc:
 //
 // autoload -U +X bashcompinit && bashcompinit"
+// autoload -Uz compinit && compinit
 // complete -C </path/to/completion/command> <command>
 type zsh struct {
 	rc string
@@ -23,8 +24,12 @@ func (z zsh) Install(cmd, bin string) error {
 
 	completeCmd := z.cmd(cmd, bin)
 	bashCompInit := "autoload -U +X bashcompinit && bashcompinit"
+	compInit := "autoload -Uz compinit && compinit"
 	if !lineInFile(z.rc, bashCompInit) {
 		completeCmd = bashCompInit + "\n" + completeCmd
+	}
+	if !lineInFile(z.rc, compInit) {
+		completeCmd = bashCompInit + "\n" + compInit + "\n" + completeCmd
 	}
 
 	return appendFile(z.rc, completeCmd)


### PR DESCRIPTION
Encountered issue when trying to install autocompletion for [terraform](https://github.com/hashicorp/terraform) on fresh MacOS with default zsh configuration, using their `terraform -install-autocomplete` command.
Raised issue on [terraform git](https://github.com/hashicorp/terraform/issues/25421) and found it imports this module.
Cloned zsh.go and added check for the line that autoloads the zsh compinit. 
Please review, thanks!