### PR TITLE
fix crash when COMP_POINT is greater than COMP_LINE size

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -78,6 +78,9 @@ func Complete(name string, cmd Completer) {
 	if err != nil {
 		panic("COMP_POINT env should be integer, got: " + point)
 	}
+	if i > len(line) {
+		i = len(line)
+	}
 
 	// Parse the command line up to the completion point.
 	args := arg.Parse(line[:i])

--- a/complete_test.go
+++ b/complete_test.go
@@ -173,7 +173,7 @@ func TestComplete(t *testing.T) {
 		{shouldExit: false, line: "", point: ""},
 		{shouldPanic: true, line: "cmd", point: ""},
 		{shouldPanic: true, line: "cmd", point: "a"},
-		{shouldPanic: true, line: "cmd", point: "4"},
+		{shouldExit: true, line: "cmd", point: "4"},
 
 		{shouldExit: true, install: "1"},
 		{shouldExit: false, install: "a"},


### PR DESCRIPTION
Some shells (inexplicably) occasionally have a COMP_POINT that is greater than the COMP_LINE size. When that happens completion should be based on length of the COMP_LINE to avoid an out of bounds error.

See the original hack fix here: https://github.com/chriswalz/bit/blob/master/cmd/bitcomplete.go on line 39