### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 go:
   - tip
-  - 1.12.x
-  - 1.11.x
-  - 1.10.x
+  - 1.13
+  - 1.14
+  - 1.15
 
 script:
   - go test -race -coverprofile=coverage.txt -covermode=atomic ./...


### PR DESCRIPTION
Adding Power support & updating the go versions to 1.13/1.14/1.15 as go>=1.13 are only supported.

Adding Power & Updating the go versions to 1.13/1.14/1.15 as lower versions are not supported.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/complete

Please let me know if you need any further details?

Thank You !!