### PR TITLE
gocomplete: do not suppress test failures

### DIFF
--- a/gocomplete/tests_test.go
+++ b/gocomplete/tests_test.go
@@ -43,7 +43,8 @@ func TestPredictions(t *testing.T) {
 func BenchmarkFake(b *testing.B) {}
 
 func Example() {
-	monkey.Patch(os.Exit, func(int) {})
+	p := monkey.Patch(os.Exit, func(int) {})
+	defer p.Unpatch()
 	os.Setenv("COMP_LINE", "go ru")
 	os.Setenv("COMP_POINT", "5")
 	main()


### PR DESCRIPTION
Ensure that the components of the `testing` package that rely on calling `os.Exit` remain functional and any test failures are actually reported back after the `monkey.Patch` in the `gocomplete.Example` test, by following up on the `monkey.Patch` call with an `Unpatch` one.

<details><summary>Now the tests fail properly as/when they should, and you can finally see what is really going on.</summary>

```shell
$ go test ./gocomplete/
run
--- FAIL: Example (0.00s)
got:

want:
run
FAIL
FAIL    github.com/posener/complete/v2/gocomplete       0.003s
FAIL
```
</details>

<details><summary>(Verbose)</summary>

```shell
$ go test -v ./gocomplete/
=== RUN   TestPredictions
=== PAUSE TestPredictions
=== CONT  TestPredictions
=== RUN   TestPredictions/predict_tests_ok
=== RUN   TestPredictions/predict_benchmark_ok
--- PASS: TestPredictions (0.00s)
    --- PASS: TestPredictions/predict_tests_ok (0.00s)
    --- PASS: TestPredictions/predict_benchmark_ok (0.00s)
=== RUN   Example
run
--- FAIL: Example (0.00s)
got:

want:
run
FAIL
FAIL    github.com/posener/complete/v2/gocomplete       0.004s
FAIL
```