### PR TITLE
complete: enable complete.Complete() output capturing

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -49,10 +49,8 @@ func (p PredictFunc) Predict(prefix string) []string {
 }
 
 var (
-	getEnv           = os.Getenv
-	exit             = os.Exit
-	out    io.Writer = os.Stdout
-	in     io.Reader = os.Stdin
+	getEnv = os.Getenv
+	exit   = os.Exit
 )
 
 // Complete the command line arguments for the given command in the case that the program
@@ -65,6 +63,10 @@ func Complete(name string, cmd Completer) {
 		doInstall   = getEnv("COMP_INSTALL") == "1"
 		doUninstall = getEnv("COMP_UNINSTALL") == "1"
 		yes         = getEnv("COMP_YES") == "1"
+	)
+	var (
+		out io.Writer = os.Stdout
+		in  io.Reader = os.Stdin
 	)
 	if doInstall || doUninstall {
 		install.Run(name, doUninstall, yes, out, in)

--- a/complete_test.go
+++ b/complete_test.go
@@ -1,6 +1,8 @@
 package complete
 
 import (
+	"io"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -160,6 +162,15 @@ func TestComplete(t *testing.T) {
 		getEnv = os.Getenv
 		exit = os.Exit
 	}()
+
+	in, out, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(o *os.File) { os.Stdout = o }(os.Stdout)
+	defer out.Close()
+	os.Stdout = out
+	go io.Copy(ioutil.Discard, in)
 
 	tests := []struct {
 		line, point string

--- a/complete_test.go
+++ b/complete_test.go
@@ -227,7 +227,7 @@ func TestComplete(t *testing.T) {
 // the output of Complete() invocations, crucial for integration tests.
 func ExampleComplete_outputCapturing() {
 	defer func(f func(int)) { exit = f }(exit)
-	defer func(f stringLookup) { getEnv = f }(getEnv)
+	defer func(f getEnvFn) { getEnv = f }(getEnv)
 	exit = func(int) {}
 
 	// This is where the actual example starts:
@@ -273,13 +273,12 @@ func TestHasPrefix(t *testing.T) {
 	}
 }
 
-// a stringLookup function maps one string to another.
-// os.GetEnv is an instance of such a function.
-type stringLookup = func(string) string
+// getEnvFn emulates os.GetEnv by mapping one string to another.
+type getEnvFn = func(string) string
 
-// promptEnv returns stringLookup func that emulates the environment
-// variables a shell would set when its prompt has the given contents.
-var promptEnv = func(contents string) stringLookup {
+// promptEnv returns getEnvFn that emulates the environment variables
+// a shell would set when its prompt has the given contents.
+var promptEnv = func(contents string) getEnvFn {
 	return func(key string) string {
 		switch key {
 		case "COMP_LINE":

--- a/complete_test.go
+++ b/complete_test.go
@@ -226,24 +226,6 @@ func TestComplete(t *testing.T) {
 // ExampleComplete_outputCapturing demonstrates the ability to capture
 // the output of Complete() invocations, crucial for integration tests.
 func ExampleComplete_outputCapturing() {
-	// a stringLookup function maps one string to another.
-	// os.GetEnv is an instance of such a function.
-	type stringLookup = func(string) string
-
-	// promptEnv returns stringLookup func that emulates the environment
-	// variables a shell would set when its prompt has the given contents.
-	var promptEnv = func(contents string) stringLookup {
-		return func(key string) string {
-			switch key {
-			case "COMP_LINE":
-				return contents
-			case "COMP_POINT":
-				return strconv.Itoa(len(contents))
-			}
-			return ""
-		}
-	}
-
 	defer func(f func(int)) { exit = f }(exit)
 	defer func(f stringLookup) { getEnv = f }(getEnv)
 	exit = func(int) {}
@@ -288,5 +270,23 @@ func TestHasPrefix(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantOK, gotOK)
 		})
+	}
+}
+
+// a stringLookup function maps one string to another.
+// os.GetEnv is an instance of such a function.
+type stringLookup = func(string) string
+
+// promptEnv returns stringLookup func that emulates the environment
+// variables a shell would set when its prompt has the given contents.
+var promptEnv = func(contents string) stringLookup {
+	return func(key string) string {
+		switch key {
+		case "COMP_LINE":
+			return contents
+		case "COMP_POINT":
+			return strconv.Itoa(len(contents))
+		}
+		return ""
 	}
 }

--- a/complete_test.go
+++ b/complete_test.go
@@ -1,7 +1,6 @@
 package complete
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -160,7 +159,6 @@ func TestComplete(t *testing.T) {
 	defer func() {
 		getEnv = os.Getenv
 		exit = os.Exit
-		out = os.Stdout
 	}()
 
 	tests := []struct {
@@ -204,7 +202,6 @@ func TestComplete(t *testing.T) {
 			exit = func(int) {
 				isExit = true
 			}
-			out = ioutil.Discard
 			if tt.shouldPanic {
 				assert.Panics(t, func() { testCmd.Complete("") })
 			} else {


### PR DESCRIPTION
By moving the input/output stream variable initializations into `complete.Complete()` it always uses the `os.Stdout` stream as it is at the moment of invocation and we ensure that its callers have an opportunity to assert control over where the output goes to. This resolves #137.

<details><summary>Now the tests actually do pass.</summary>

```shell
$ go test -run=^Example -v . ./gocomplete/
=== RUN   ExampleComplete_outputCapturing
--- PASS: ExampleComplete_outputCapturing (0.00s)
PASS
ok      github.com/posener/complete/v2  0.003s
=== RUN   Example
--- PASS: Example (0.00s)
PASS
ok      github.com/posener/complete/v2/gocomplete       0.004s
```
</details>

<details><summary>And they really do expose failures — or unexpected output at the very least.</summary>

```diff
diff --git a/complete_test.go b/complete_test.go
index 182ca4c..8744b56 100644
--- a/complete_test.go
+++ b/complete_test.go
@@ -256,7 +256,7 @@ func ExampleComplete_outputCapturing() {
 	Complete("foo", cmd)
 
 	// Output:
-	// bar
+	// qux
 }
 
 type set []string
diff --git a/gocomplete/tests_test.go b/gocomplete/tests_test.go
index a1238a4..c7436c8 100644
--- a/gocomplete/tests_test.go
+++ b/gocomplete/tests_test.go
@@ -48,7 +48,7 @@ func Example() {
 	os.Setenv("COMP_LINE", "go ru")
 	os.Setenv("COMP_POINT", "5")
 	main()
-	// output: run
+	// output: duck
 }
 
 func equal(s1, s2 []string) bool {
```

```shell
$ go test -run=^Example -v . ./gocomplete/
=== RUN   ExampleComplete_outputCapturing
--- FAIL: ExampleComplete_outputCapturing (0.00s)
got:
bar
want:
qux
FAIL
FAIL    github.com/posener/complete/v2  0.003s
=== RUN   Example
--- FAIL: Example (0.00s)
got:
run
want:
duck
FAIL
FAIL    github.com/posener/complete/v2/gocomplete       0.003s
FAIL
```
</details>

One lesson that should be learned from this is that actually asserting on the expected output in the `complete` tests would have exposed this much sooner.