### PR TITLE
complete: add SetExitFunc() to override os.Exit in tests

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -53,6 +53,14 @@ var (
 	exit   = os.Exit
 )
 
+// SetExitFunc sets the function used to exit the program (by default os.Exit)
+// and returns the previous value.
+func SetExitFunc(fn func(code int)) (previous func(int)) {
+	previous = exit
+	exit = fn
+	return previous
+}
+
 // Complete the command line arguments for the given command in the case that the program
 // was invoked with COMP_LINE and COMP_POINT environment variables. In that case it will also
 // `os.Exit()`. The program name should be provided for installation purposes.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/posener/complete/v2
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/posener/autogen v0.0.2
 	github.com/posener/script v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,9 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/gocomplete/tests_test.go
+++ b/gocomplete/tests_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/posener/complete/v2"
 )
 
@@ -53,8 +52,8 @@ func TestPredictions(t *testing.T) {
 func BenchmarkFake(b *testing.B) {}
 
 func Example() {
-	p := monkey.Patch(os.Exit, func(int) {})
-	defer p.Unpatch()
+	p := complete.SetExitFunc(func(int) {})
+	defer complete.SetExitFunc(p)
 	os.Setenv("COMP_LINE", "go ru")
 	os.Setenv("COMP_POINT", "5")
 	main()
@@ -76,7 +75,8 @@ func equal(s1, s2 []string) bool {
 }
 
 func TestErrorSupression(t *testing.T) {
-	defer monkey.Patch(os.Exit, func(int) {}).Unpatch()
+	p := complete.SetExitFunc(func(int) {})
+	defer complete.SetExitFunc(p)
 
 	// Completion API environment variable names.
 	const envLine, envPoint = "COMP_LINE", "COMP_POINT"


### PR DESCRIPTION
This eliminates the need to use the unsupported bou.ke/monkey package,
which fails to build on darwin/arm64. A better solution might be to remove
the use of `os.Exit` entirely since it's only called with `os.Exit(0)` and exiting
the program should be the responsibility of the caller to `Complete`.